### PR TITLE
Add mcf thread model to build matrix

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,7 +27,7 @@ jobs:
       fail-fast: false
       matrix:
         arch: [x86_64, i686]
-        threads: [posix, win32]
+        threads: [posix, win32, mcf]
         exceptions: [seh, dwarf]
         msvcrt: [msvcrt, ucrt]
         exclude:
@@ -35,6 +35,8 @@ jobs:
             exceptions: dwarf
           - arch: i686
             exceptions: seh
+          - threads: mcf
+            msvcrt: msvcrt
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
I intentionally excluded "mcf thread model with msvcrt runtime" configurations because there will be little demand for them.